### PR TITLE
Cleanup and update of makefile & DoubleVector demo

### DIFF
--- a/double-vector/makefile
+++ b/double-vector/makefile
@@ -1,10 +1,11 @@
 # makefile
 #
 
+all: doubleVector.bundle
 
-all:
+doubleVector.bundle: doubleVector.cc
 	$(CLANG) $(OPTIONS) -o doubleVector.bundle doubleVector.cc
 
 
-test:
+test: doubleVector.bundle
 	$(CLASP_BOEHM) -l double-vector.lsp

--- a/makefile
+++ b/makefile
@@ -1,6 +1,5 @@
 # makefile
 #
-
 include local.config
 
 ifeq ($(CLANG),)
@@ -41,7 +40,7 @@ export DARWIN_OPTIONS = -bundle -DUSE_BOEHM -std=c++11 -stdlib=libc++ \
 			-lreadline
 
 #			-resource-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/6.0 \
-#			-resource-dir $(EXTERNALS_BUILD_TARGET_DIR)/release/bin/../lib/clang/3.6.0 \
+#			-resource-dir $(EXTERNALS_BUILD_TARGET_DIR)/release/bin/../lib/clang/3.6.1 \
 
 #From makefile.faheem
 
@@ -51,10 +50,14 @@ export LINUX_OPTIONS = -v \
 			-std=c++11 \
 			-D_TARGET_OS_LINUX \
 			-DNDEBUG \
+			-DBUILDING_CLASP \
 			-DUSE_BOEHM \
+			-iquote $(CLASP_SOURCE)/../include/clasp/main \
+			-iquote $(CLASP_SOURCE)/../include/clasp \
+			-I $(CLASP_SOURCE)/../include \
 			-I $(CLASP_SOURCE)/include \
-			-I $(CLASP_SOURCE)/core/bin/boehm/clang-linux-3.6.0/release/link-static \
-			-I $(CLASP_SOURCE)/clbind/bin/boehm/clang-linux-3.6.0/release/link-static \
+			-I $(CLASP_SOURCE)/core/bin/boehm/clang-linux-3.6.1/release/link-static \
+			-I $(CLASP_SOURCE)/clbind/bin/boehm/clang-linux-3.6.1/release/link-static \
 			-I $(CLASP_SOURCE) \
 			-Wl,--start-group \
 			$(CLASP_SOURCE)/gctools/bundle/libgctools_boehm_opt.a \
@@ -88,7 +91,7 @@ export LINUX_OPTIONS_OLD_BROKEN = -v -shared -DUSE_BOEHM -std=c++11 -stdlib=libc
 		-I $(CLASP_SOURCE)/clbind/bin/boehm/clang-darwin-4.2.1/release/link-static \
 		-I $(EXTERNALS_BUILD_TARGET_DIR)/common/include \
 		-I $(EXTERNALS_BUILD_TARGET_DIR)/release/include \
-		-I $(EXTERNALS_BUILD_TARGET_DIR)/release/lib/clang/3.6.0/include \
+		-I $(EXTERNALS_BUILD_TARGET_DIR)/release/lib/clang/3.6.1/include \
 		-L $(CLASP_SOURCE)/gctools/bundle \
 		-l gctools_boehm_opt \
 		-L $(CLASP_SOURCE)/core/bundle \
@@ -106,7 +109,6 @@ ifeq ($(TARGET_OS),darwin)
 else
 	export OPTIONS = $(LINUX_OPTIONS) $(LOCAL_OPTIONS)
 endif
-
 
 all:
 	(cd hello-world; make $*)


### PR DESCRIPTION
Instead of using Clasp-internal conversions, call other translators from inside the vector translator.
This improves maintainability & readability.
